### PR TITLE
fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,20 @@ Database of Local Volume dwarf galaxies and  star clusters. The database is comp
 The planned limiting distance is ~10+ Mpc (i.e. resolved stars with HST or JWST).  
 The star cluster collections are currently limited to old star clusters/globular clusters in the Milky Way halo and globular clusters/star clusters hosted by low mas dwarf galaxies.
 
-The main data tables are located in the [`data/`](data/) folder in `csv` format. 
-A summary pdf document of the database content and additional data files in `fits` format are on the release page available. 
+The main data tables are located in the release pages in `csv` and `fits` file formats. The data tables are also available in the [`data/`](data/) folder in `csv` format. 
+A summary pdf document of the database content is available in the release page. 
 
 Documentation: [readthedocs](https://local-volume-database.readthedocs.io/en/latest/index.html).
 
-Overview paper: [arXiv](https://arxiv.org/abs/2411.07424)[ADS](https://ui.adsabs.harvard.edu/abs/2024arXiv241107424P/abstract).
+Overview paper: [arXiv](https://arxiv.org/abs/2411.07424) and  [ADS](https://ui.adsabs.harvard.edu/abs/2024arXiv241107424P/abstract).
 
 The tables can be directly loaded into Jupyter notebooks without having to download the repository:
 
     import astropy.table as table
-    dwarf_mw = table.Table.read('https://raw.githubusercontent.com/apace7/local_volume_database/main/data/dwarf_mw.csv')
-    # or from the release page
-    dwarf_mw = table.Table.read('https://github.com/apace7/local_volume_database/releases/download/v0.0.2/dwarf_all.csv')
+    ## from the release page (recommended)
+    dwarf_mw = table.Table.read('https://github.com/apace7/local_volume_database/releases/download/v1.0.0/dwarf_all.csv')
+    # or from a  github branch
+    dwarf_mw = table.Table.read('https://raw.githubusercontent.com/apace7/local_volume_database/main/data/dwarf_mw.csv') 
 
 
 ### ACKNOWLEDGEMENT:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The main data tables are located in the [`data/`](data/) folder in `csv` format.
 A summary pdf document of the database content and additional data files in `fits` format are on the release page available. 
 
 Documentation: [readthedocs](https://local-volume-database.readthedocs.io/en/latest/index.html).
-Overview paper: [arXiv](https://arxiv.org/abs/2411.07424).
+
+Overview paper: [arXiv](https://arxiv.org/abs/2411.07424)[ADS](https://ui.adsabs.harvard.edu/abs/2024arXiv241107424P/abstract).
 
 The tables can be directly loaded into Jupyter notebooks without having to download the repository:
 
@@ -22,7 +23,7 @@ The tables can be directly loaded into Jupyter notebooks without having to downl
 
 ### ACKNOWLEDGEMENT:
 
-If you use this in your research please include a link to the github repository (https://github.com/apace7/local_volume_database) and cite the database paper. It is highly encouraged to cite the input references of the database if they are used in your work. An example in latex is: This work has made use of the Local Volume Database\footnote{\url{https://github.com/apace7/local_volume_database }} \citep{}. The BibTex of the citation is available here.
+If you use this in your research please include a link to the github repository (https://github.com/apace7/local_volume_database) and cite the database paper. It is highly encouraged to cite the input references of the database if they are used in your work. An example in latex is: This work has made use of the Local Volume Database\footnote{\url{https://github.com/apace7/local_volume_database }} \citep{Pace2024arXiv241107424P}. The BibTex of the citation is available here [ADS]{https://ui.adsabs.harvard.edu/abs/2024arXiv241107424P/exportcitation}.
 
 The LVDB releases are also indexed on [zenodo](https://doi.org/10.5281/zenodo.14076714).
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,9 @@ Welcome to the local_volume_database documentation!
 
 **local_volume_database** is a Python library of the fundamental properties of dwarf galaxies and star clusters in the Local Volume. 
 
-`Link to GitHub repository <https://github.com/apace7/local_volume_database>`_
-
+Some useful links:
+* `Link to GitHub repository <https://github.com/apace7/local_volume_database>`_
+* `ADS Link to Overview paper  <https://ui.adsabs.harvard.edu/abs/2024arXiv241107424P/abstract>`_
 
 .. The primary database catalogs are located as attachments in the: `Release Pages <https://github.com/apace7/local_volume_database/releases>`_ and the catalog columns are described in :doc:`usage`. The catalogs are  included as both csv and  fits files.
 .. There is also a pdf summary file of the LVDB content.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -369,9 +369,11 @@ As ADS bibcode are a fixed length of 19 characters, the ADS bibcode can be retri
 
 Users of the LVDB are encouraged to cite the LVDB input (of the systems studied in their analysis) to give proper acknowledgment to the community.  The references could be included in a table or appendix. See Appendix A of this paper (`Cerny et al. 2024 <https://ui.adsabs.harvard.edu/abs/2024arXiv241000981C/abstract>`_) for an example of including internal LVDB references to the text of a paper.
 
-If you use the LVDB in your research please include a link to the github repository (https://github.com/apace7/local_volume_database) and cite the LVDB overview paper. 
-An example in LaTeX that can be added to the acknowledgments section is: This work has made use of the Local Volume Database\footnote{\url{https://github.com/apace7/local_volume_database }} \citep{}.
+If you use the LVDB in your research please include a link to the github repository (https://github.com/apace7/local_volume_database) and cite the LVDB overview paper (`Pace 2024 <https://ui.adsabs.harvard.edu/abs/2024arXiv241107424P/abstract>`_). 
+An example in LaTeX that can be added to the acknowledgments section is: This work has made use of the Local Volume Database\footnote{\url{https://github.com/apace7/local_volume_database }} \citep{Pace2024arXiv241107424P}.
 
 The LVDB releases are also indexed on `zenodo <https://doi.org/10.5281/zenodo.14076714>`_.
+
+Link to the LVDB overview paper  on `arXiv <https://arxiv.org/abs/2411.07424>`_. and `ADS <https://ui.adsabs.harvard.edu/abs/2024arXiv241107424P/abstract>`_. 
 
 .. The bibtex of the LVDB paper is below:

--- a/table/lvdb.bib
+++ b/table/lvdb.bib
@@ -12559,6 +12559,22 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{Pace2024arXiv241107424P,
+       author = {{Pace}, Andrew B.},
+        title = "{The Local Volume Database: a library of the observed properties of nearby dwarf galaxies and star clusters}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Astrophysics of Galaxies},
+         year = 2024,
+        month = nov,
+          eid = {arXiv:2411.07424},
+        pages = {arXiv:2411.07424},
+archivePrefix = {arXiv},
+       eprint = {2411.07424},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv241107424P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 
 
 


### PR DESCRIPTION
fixed a few typos in the docs and in data files;
modified the sky plots in `example_plots.ipynb` to flip the direction of longitude axis, to match the standard astronomical convention. Seems to be impossible to achieve using the standard `ax.invert_xaxis()` – it does nothing; there is even an old (~10 years ago!) issue raised by Adrian about this: https://github.com/matplotlib/matplotlib/issues/4515/ – and nothing has been done since then! I don't know how other people get around this problem; I personally don't use matplotlib's cartographic projections at all, instead performing coordinate transformations manually and rendering the plots as I wish. In the GalStreams package, `invert_xaxis()` [works](https://github.com/cmateu/galstreams/blob/5f3125fec686c1aa199c374135010e2595ba56ed/galstreams/core.py#L721), but only because the code uses another mechanism for rendering geographic projections (`mpl_toolkits.basemap`).